### PR TITLE
Step16 priority

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -55,7 +55,7 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name,:content,:limit_on,:status)
+    params.require(:task).permit(:name,:content,:limit_on,:status,:priority)
   end
 
   def set_task

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,6 +4,8 @@ class TasksController < ApplicationController
   def index
     if params[:sort_expired]
       @tasks = Task.all.order(limit_on: "DESC")
+    elsif params[:sort_priority]
+      @tasks = Task.all.order(priority: "DESC")
     else
       @tasks = Task.all.order(created_at: "DESC")
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -14,4 +14,10 @@ class Task < ApplicationRecord
   scope :status_search, -> status {where(status: status)}
   # name と statusから一致する条件を返す
   scope :name_status_search, -> (name, status) { where("name like ?", "%#{name}%").where(status: status)}
+
+  # ステップ16対応 優先順位
+  enum priority: { low: 0, medium: 1, high: 2,}
+  # priority から一致するものを探す
+  scope :priority_search, -> priority{where(priority: priority)}
+
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -28,8 +28,8 @@
     <td><%= task.name %></td>
     <td><%= task.content %></td>
     <td><%= task.limit_on %></td>
-    <td><%= task.status %></td>
-    <td><%= task.priority %></td>
+    <td><%= task.status_i18n %></td>
+    <td><%= task.priority_i18n %></td>
 
     <td><%= link_to t('index.show'), task_path(task.id) %></td>
     <td><%= link_to t('index.edit'), edit_task_path(task.id), data: {confirm: '編集確認'} %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -8,12 +8,19 @@
   <%= f.submit t('index.search') %>
 <% end %>
 
+<%= form_with(model: Task.new, url: search_tasks_path, method: :get, local: true) do |f| %>
+  <%= f.label :priority_search, t('index.priority_search') %>
+  <%= f.select :priority_search, Task.priorities_i18n.invert, include_blank: true, selected: "" %>
+  <%= f.submit t('index.search') %>
+<% end %>
+
 <table>
   <tr>
     <th>名前</th>
     <th>内容</th>
     <th>終了期限</th>
     <th>ステータス</th>
+    <th>優先度</th>
   </tr>
 
 <% @tasks.each do |task| %>
@@ -22,6 +29,7 @@
     <td><%= task.content %></td>
     <td><%= task.limit_on %></td>
     <td><%= task.status %></td>
+    <td><%= task.priority %></td>
 
     <td><%= link_to t('index.show'), task_path(task.id) %></td>
     <td><%= link_to t('index.edit'), edit_task_path(task.id), data: {confirm: '編集確認'} %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -8,12 +8,6 @@
   <%= f.submit t('index.search') %>
 <% end %>
 
-<%= form_with(model: Task.new, url: search_tasks_path, method: :get, local: true) do |f| %>
-  <%= f.label :priority_search, t('index.priority_search') %>
-  <%= f.select :priority_search, Task.priorities_i18n.invert, include_blank: true, selected: "" %>
-  <%= f.submit t('index.search') %>
-<% end %>
-
 <table>
   <tr>
     <th>名前</th>
@@ -40,6 +34,7 @@
 
 <p><%= link_to t('index.new'), new_task_path %></p>
 <p><%= link_to t('index.limit_on_sort'), tasks_path(sort_expired: "true") %></p>
+<p><%= link_to t('index.priority_sort'), tasks_path(sort_priority: "true") %></p>
 <p><%= link_to t('index.index'), tasks_path %></p>
 
 <%= t('view.sample') %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -15,6 +15,10 @@
     <%= form.label :status %>
     <%= form.select :status, Task.statuses_i18n.invert %>
   </div>
+  <div class="task_priority">
+    <%= form.label :priority %>
+    <%= form.select :priority, Task.priorities_i18n.invert %>
+  </div>
 
   <%= form.submit %>
 <% end %>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -8,3 +8,4 @@ ja:
         content: "内容"
         limit_on: 終了期限
         status: ステータス
+        priority: 優先度

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -11,7 +11,7 @@ ja:
     search: 検索する
     name_search: 名前検索
     status_search: ステータス検索
-    priority_search: 優先度検索
+    priority_sort: 優先度でソートする
   enums:
     task:
       status:

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -11,9 +11,14 @@ ja:
     search: 検索する
     name_search: 名前検索
     status_search: ステータス検索
+    priority_search: 優先度検索
   enums:
     task:
       status:
         nowork: "未着手"
         work: "着手中"
         comp: "完了"
+      priority:
+        low: 低
+        medium: 中
+        high: 高

--- a/db/migrate/20190107092643_add_priority_to_task.rb
+++ b/db/migrate/20190107092643_add_priority_to_task.rb
@@ -1,6 +1,5 @@
 class AddPriorityToTask < ActiveRecord::Migration[5.2]
   def change
     add_column :tasks, :priority, :integer, null: false,  default: 0
-    add_index :tasks, :priority
   end
 end

--- a/db/migrate/20190107092643_add_priority_to_task.rb
+++ b/db/migrate/20190107092643_add_priority_to_task.rb
@@ -1,0 +1,6 @@
+class AddPriorityToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :priority, :integer, null: false,  default: 0
+    add_index :tasks, :priority
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,7 +24,6 @@ ActiveRecord::Schema.define(version: 2019_01_07_092643) do
     t.integer "status", default: 0, null: false
     t.integer "priority", default: 0, null: false
     t.index ["name"], name: "index_tasks_on_name"
-    t.index ["priority"], name: "index_tasks_on_priority"
     t.index ["status"], name: "index_tasks_on_status"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_05_214653) do
+ActiveRecord::Schema.define(version: 2019_01_07_092643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,7 +22,9 @@ ActiveRecord::Schema.define(version: 2019_01_05_214653) do
     t.datetime "updated_at", null: false
     t.date "limit_on", default: "1900-01-01", null: false
     t.integer "status", default: 0, null: false
+    t.integer "priority", default: 0, null: false
     t.index ["name"], name: "index_tasks_on_name"
+    t.index ["priority"], name: "index_tasks_on_priority"
     t.index ["status"], name: "index_tasks_on_status"
   end
 

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
     content { 'search_content01' }
     limit_on { '20000101' }
     status { 'nowork' }
+    priority { 'low' }
   end
 
   factory :search_02, class: Task do
@@ -43,6 +44,7 @@ FactoryBot.define do
     content { 'search_content02' }
     limit_on { '20000102' }
     status { 'work' }
+    priority {'medium'}
   end
 
   factory :search_03, class: Task do
@@ -50,6 +52,7 @@ FactoryBot.define do
     content { 'search_content01' }
     limit_on { '20000103' }
     status { 'comp' }
+    priority {'high'}
   end
 
   factory :search_04, class: Task do

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -102,10 +102,10 @@ RSpec.feature "検索機能テスト",type: :feature do
     click_on '検索する'
     expect(page).to have_content 'search_name01'
     expect(page).to have_content '2000-01-01'
-    expect(page).to have_content 'nowork'
+    expect(page).to have_content '未着手'
     expect(page).to have_content 'search_name01'
     expect(page).to have_content '2000-01-03'
-    expect(page).to have_content 'comp'
+    expect(page).to have_content '完了'
   end
 
   scenario "ステータス検索テスト" do
@@ -129,6 +129,22 @@ RSpec.feature "検索機能テスト",type: :feature do
     expect(page).to have_content '2000-01-02'
     expect(page).to have_content '着手中'
     save_and_open_page
+  end
+end
+
+RSpec.feature "優先度ソートテスト",type: :feature do
+  background do
+    FactoryBot.create(:search_01)
+    FactoryBot.create(:search_02)
+    FactoryBot.create(:search_03)
+  end
+
+  scenario "優先順位ソート" do
+    visit tasks_path
+    click_on '優先度でソートする'
+    expect(page).to have_content '高'
+    expect(page).to have_content '中'
+    expect(page).to have_content '低'
   end
 
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -54,8 +54,15 @@ RSpec.feature "タスク管理機能",type: :feature do
     expect(page).to have_content 'testtesttest1'
     expect(page).to have_content 'samplesample1'
   end
+end
 
-  # RSpec.feature "終了期限テスト",type: :feature do
+RSpec.feature "終了期限テスト",type: :feature do
+  background do
+    FactoryBot.create(:task)
+    FactoryBot.create(:limit_on_sort01)
+    FactoryBot.create(:limit_on_sort02)
+  end
+
   scenario "終了期限作成テスト" do
     visit new_task_path
     fill_in 'task_name', with: 'name'
@@ -67,8 +74,6 @@ RSpec.feature "タスク管理機能",type: :feature do
   end
 
   scenario "終了期限でソートするボタンのテスト" do
-    FactoryBot.create(:limit_on_sort01)
-    FactoryBot.create(:limit_on_sort02)
     visit tasks_path
     click_on '終了期限でソートする'
     expect(page).to have_content 'limit_on_sort02_name'
@@ -81,13 +86,17 @@ RSpec.feature "タスク管理機能",type: :feature do
     expect(page).to have_content 'samplesample1'
     expect(page).to have_content '1900-01-01'
   end
+end
 
-  # RSpec.feature "検索機能テスト",type: :feature do
-  scenario "名前検索テスト" do
+RSpec.feature "検索機能テスト",type: :feature do
+  background do
     FactoryBot.create(:search_01)
     FactoryBot.create(:search_02)
     FactoryBot.create(:search_03)
     FactoryBot.create(:search_04)
+  end
+
+  scenario "名前検索テスト" do
     visit tasks_path
     fill_in 'task_name', with: 'search_name01'
     click_on '検索する'
@@ -100,10 +109,6 @@ RSpec.feature "タスク管理機能",type: :feature do
   end
 
   scenario "ステータス検索テスト" do
-    FactoryBot.create(:search_01)
-    FactoryBot.create(:search_02)
-    FactoryBot.create(:search_03)
-    FactoryBot.create(:search_04)
     visit tasks_path
     select '完了', from: 'task[status]'
     click_on '検索する'
@@ -116,10 +121,6 @@ RSpec.feature "タスク管理機能",type: :feature do
   end
 
   scenario "名前、ステータス同時検索テスト" do
-    FactoryBot.create(:search_01)
-    FactoryBot.create(:search_02)
-    FactoryBot.create(:search_03)
-    FactoryBot.create(:search_04)
     visit tasks_path
     fill_in 'task_name', with: 'search_name02'
     select '着手中', from: 'task[status]'


### PR DESCRIPTION
step16の実装手順
優先順位の(priority)のカラムを作成

rails g migration AddPriorityToTask

add_column :tasks, :priority, integer, null: false, default: 0

migrate

コントローラーのストロングパラメータに priority を追加

enum を作成 task.model に追記
enum priority: {
  low: 0,
  medium: 1,
  high: 2,
}

view/task/index に優先順位にソートするボタンを作成
<p><%= link_to t('index.prioryty_sort'), tasks_path(sort_expired: "true") %></p>

controller/task のindexで parms[:sort_exipired] が使えるようになるので、コントローラーを修正
elsif params[:sort_priority]
  @tasks = Task.all.order(priority: "DESC")

表示領域の作成

view/task/new に優先度の登録領域の作成

i18n を整理するのでconfig/yml ファイルを修正

rspec を作成
